### PR TITLE
Fixing packaging issue preventing dependencies from being uploaded too

### DIFF
--- a/sam_handler/handler.py
+++ b/sam_handler/handler.py
@@ -245,7 +245,6 @@ class SAM(TemplateHandler):
             'region': self.connection_manager.region,
             's3-prefix': self.artifact_key_prefix,
             'output-template-file': self.destination_template_path,
-            'template-file': str(self.sam_template_path.absolute())
         }
         package_args = {**default_args, **self.arguments.get('package_args', {})}
         invoker.invoke('package', package_args)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 TEMPLATE_HANDLER_NAME = 'sceptre-sam-handler'
 TEMPLATE_HANDLER_TYPE = 'sam'

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -100,7 +100,6 @@ class TestSAM(FsTestCase):
                 'region': self.region,
                 's3-prefix': expected_prefix,
                 'output-template-file': expected_temp_dir,
-                'template-file': str(Path(self.arguments['path']).absolute())
             }
         )
 
@@ -123,7 +122,6 @@ class TestSAM(FsTestCase):
                 'region': self.region,
                 's3-prefix': expected_prefix,
                 'output-template-file': expected_temp_dir,
-                'template-file': str(Path(self.arguments['path']).absolute()),
                 'new': 'arg'
             }
         )


### PR DESCRIPTION
I discovered an issue where the compiled dependencies from layers and functions are not actually being uploaded. 

The cause of this is because the handler is directing `sam package` to use the **pre**-build template (located at the template handler's "path" argument) rather than the **post**-build template (which will be in the pre-build template's `.aws-sam` directory). We don't actually need to specify the template path anyway, since it's only in special circumstances that this would ever be needed; `sam package` uses the right directory and template by default. 