### PR TITLE
Supporting Jinja templates for the SAM Handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 <!--- All unreleased items go here  -->
 
 
-## 0.2.2
+## 0.2.0
 ### ADDED
 * Jinja template support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,8 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 
 ## 0.2.0
-### ADDED
+### Added
 * Jinja template support
+
+### Nonfunctional
+* New/modified documentation to reflect using `!stack_attr` and Jinja2 templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,7 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 <!--- All unreleased items go here  -->
 
-<!--- Example CHANGELOG entry
 
-## 0.1.0 (2019.07.02)
-
-### Added
-
-- Initial template handler code
-
--->
+## 0.2.2
+### ADDED
+* Jinja template support

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 AWS SAM template (and its associated project) as a stack's template.
 
 This template handler will run `sam build` and then `sam package` from the indicated SAM Template's
-directory in order to generate a CloudFormation-ready template.
+directory in order to compile and generate a CloudFormation-ready template. Additionally, if you
+define your SAM template with a `.j2` extension, you can utilize [Jinja2 templating syntax and logic](
+https://jinja.palletsprojects.com/en/3.1.x/templates/) to render the SAM template prior to the build. 
 
-**By using the SAM Handler, you are letting SAM compile a SAM template and upload artifacts to S3,
-and then using Sceptre to actually do the deployment of the template to a stack.** In other words,
-by using this handler with Sceptre, _you skip ever using `sam deploy`; It's not needed_. You also
-likely won't need a sam config file with deployment defaults, since you'll be using Sceptre to
+**By using the SAM Handler, you are letting SAM build your application, compile a SAM template, and 
+upload artifacts to S3, and then using Sceptre to actually do the deployment of the template to a stack.** 
+In other words, by using this handler with Sceptre, _you skip ever using `sam deploy`; It's not needed_. 
+You also shouldn't need a sam config file with deployment defaults, since you'll be using Sceptre to
 deploy rather than SAM.
 
 By using this handler, you can now use SAM templates with all your favorite Sceptre commands, like
@@ -18,14 +20,33 @@ By using this handler, you can now use SAM templates with all your favorite Scep
 
 ## How to install sceptre-sam-handler
 
-Simply `pip install scepre-sam-handler`.
+Simply `pip install scepre-sam-handler`. **Additionally, you need SAM CLI installed and accessible** on
+the PATH for the handler to invoke as a subprocess.
 
-If you want to install `aws-sam-cli` along with this handler using `pip`, you can use the "extra"
-like `pip install sceptre-sam-handler[sam]`.
+There are three main ways you can install SAM CLI:
+* You can follow [AWS's own documentation](
+https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
+on how to install SAM for your operating system. (Note: at least on Linux, this requires the ability
+to use `sudo`; If you need to install SAM where permissions escalation is not possible, this won't
+work.)
+* You can use [pipx](https://github.com/pypa/pipx) to install `aws-sam-cli` into an isolated virtual 
+environment where it can have exclusive claim to its dependency versions. This can be done without 
+privilege escalations.
+* If you want to install `aws-sam-cli` along with this handler using `pip`, you can use the "extra"
+like `pip install sceptre-sam-handler[sam]`. However, **using pip to install SAM is generally not 
+recommended, according to SAM's own documentation.** This can lead to dependency conflicts, since
+SAM CLI is particular about dependency versions.
 
 ## How to use sceptre-sam-handler
 
-The template "type" for this handler is `sam`.
+The template "type" for this handler is `sam`. There are two file extensions supported by this
+handler:
+* `.yaml`: Use this for a "normal" SAM template according to the SAM specification. This template
+will be directly sent to the SAM CLI for building and packaging.
+* `.j2`: Use this if you need to use [Jinja2 templating syntax and logic](
+https://jinja.palletsprojects.com/en/3.1.x/templates/) in order to render a SAM template, such as
+to interpolate values into the template prior to building it. See the section below on Jinja SAM
+templates for more details.
 
 This handler takes several arguments, two of which are required.
 
@@ -49,7 +70,7 @@ When using _only_ sam CLI (not Sceptre) to deploy using `sam deploy`, SAM CLI ef
 
 1. SAM CLI builds the all the various resources special SAM resources, resolving dependencies. These would
 include Lambda functions and Lambda layers. It copies any locally-referenced files and resolves any
-dependencies into a directory called `.aws-sam`. This is the sam behavior as running `sam build`.
+dependencies into a directory called `.aws-sam`. This is the same behavior as running `sam build`.
 2. SAM CLI then transforms all SAM template URIs that reference local filepaths to S3 keys (among other)
 transformations it applies, uploads any built artifacts to those s3 keys, and saves the transformed
 template. This is the same behavior as running `sam package`.
@@ -57,7 +78,7 @@ template. This is the same behavior as running `sam package`.
 arguments) and performs CloudFormation stack create/update with them.
 
 When you use Sceptre with this handler, the SAM handler performs steps 1-2 above to create a template
-that Sceptre can use, **but it does not use sam to deploy it!**. Instead, Sceptre can use that template
+that Sceptre can use, **but it does not use SAM to deploy it!**. Instead, Sceptre can use that template
 produced in step 2 above (via `sam package`) to perform all it's usual commands with all it's usual
 magic!
 
@@ -110,11 +131,30 @@ https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/s
 
 ### Jinja SAM Templates
 The SAM Handler supports using SAM templates that have Jinja logic in them. These Jinja templates
-will have access to the sceptre_user_data just like Jinja templates via the normal file handler
+will have access to the `sceptre_user_data` just like Jinja templates via the normal file handler
 do. This can be useful for implementing additional template logic (such as loops and other actions)
-in the template.
+in the template. 
 
-### Example Stack Config
+If you need to pass variables into the Jinja template for reference via Jinja syntax,
+you should pass those variables via `sceptre_user_data`. Remember, resolvers can be used with
+`sceptre_user_data`, so this can be a powerful tool to pre-render your templates or reference values
+in areas that a SAM Template cannot use parameters (such as in Transforms).
+
+### Resolvers in the SAM Handler parameters
+It's likely that you'll want to use your template_bucket_name as your artifact_bucket_name, so you
+don't need to have a separate bucket for your sam artifacts. However, since template_bucket_name is 
+technically a resolvable property that could be set via `!stack_output` on your StackGroup config,
+you cannot directly reference it in your Stack Config with `{{ template_bucket_name }}` if you defined
+it on the StackGroup Config using a resolver. For more information on _why_ you can't do this, you 
+should read about the [Resolution order of values](
+https://docs.sceptre-project.org/3.1.0/docs/stack_config.html#resolution-order-of-values) for Sceptre
+Stack Configs on Sceptre's documentation.
+
+Nonetheless, the bottom line is this: `{{ template_bucket_name }}` may or may not actually work for
+you, but `!stack_attr template_bucket_name` will **always** work for you, no matter how you've set
+up your project.
+
+### Example Stack Config (simple .yaml)
 ```yaml
 # By using the SAM handler, you let SAM build and package the template and upload artifacts to S3
 # and Sceptre will use the packaged template to create the CloudFormation stack, using the stack
@@ -122,8 +162,14 @@ in the template.
 template:
     type: sam
     path: path/from/my/cwd/template.yaml
-    artifact_bucket_name: {{ template_bucket_name }}
-    artifact_prefix: {{ template_key_prefix }}
+    # If your template_bucket_name is inherited from your StackGroup as a resolver, you cannot use
+    # {{ template_bucket_name }} to reference it, so you need to use the !stack_attr resolver. But
+    # using !stack_attr will always work for you anyway, so you might as well configure the SAM 
+    # handler that way.
+    artifact_bucket_name: !stack_attr template_bucket_name
+    # It makes the most sense to use the same prefix as your template_key_prefix so that your SAM
+    # artifacts are foldered similar to your other templates... but it's not strictly necessary.
+    artifact_prefix: !stack_attr template_key_prefix
     build_args:
         use-container: True
 
@@ -136,7 +182,28 @@ parameters:
 profile: my_profile
 iam_role: arn:aws:iam::1111111111:role/My-Deployment-Role
 region: us-east-1
-
 stack_tags:
     SomeTag: SomeValue
+```
+
+### Example Stack Config (Using Jinja2 .j2 template)
+```yaml
+template:
+    type: sam
+    path: path/from/my/cwd/template.j2
+    artifact_bucket_name: !stack_attr template_bucket_name
+    artifact_prefix: !stack_attr template_key_prefix
+
+# Remember, Jinja logic cannot access parameter values; Those are accessed via CloudFormation functions
+# like !Ref and !Sub when the stack is being deployed. If you need values to use with your Jinja logic,
+# use sceptre_user_data instead.
+parameters:
+    my_template_parameter: !stack_output some/other/stack.yaml::SomeOutput
+
+# sceptre_user_data is resolved PRIOR TO building and deploying the template and it is passed to 
+# Jinja. So you can use sceptre_user_data to control Jinja logic or render values into the template.
+# And because sceptre_user_data is resolvable, you can use resolvers to pass values and even whole
+# template segments to render into the final SAM template before SAM build is ever invoked.
+sceptre_user_data:
+     template_segmant: !file my/template/segment
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This handler takes several arguments, two of which are required.
 
 ### Arguments:
 * `path` (string, required): The path **from the current working directory** (NOT the
-* project path) to the SAM Template.
+* project path) to the SAM Template. Paths to Jinja (.j2) files _are_ supported.
 * `artifact_bucket_name` (string, required): The bucket name where artifacts should be uploaded to
 on S3 during the packaging process. If your project has a `template_bucket_name`, you can set this
 to `{{ template_bucket_name }}`.
@@ -107,6 +107,12 @@ handler. You will need to ensure that any user or role executing these commands 
 permissions for these operations. For more information on required permissions, see the
 [documentation for SAM permissions](
 https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-permissions.html).
+
+### Jinja SAM Templates
+The SAM Handler supports using SAM templates that have Jinja logic in them. These Jinja templates
+will have access to the sceptre_user_data just like Jinja templates via the normal file handler
+do. This can be useful for implementing additional template logic (such as loops and other actions)
+in the template.
 
 ### Example Stack Config
 ```yaml

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ AWS SAM template (and its associated project) as a stack's template.
 This template handler will run `sam build` and then `sam package` from the indicated SAM Template's
 directory in order to compile and generate a CloudFormation-ready template. Additionally, if you
 define your SAM template with a `.j2` extension, you can utilize [Jinja2 templating syntax and logic](
-https://jinja.palletsprojects.com/en/3.1.x/templates/) to render the SAM template prior to the build. 
+https://jinja.palletsprojects.com/en/3.1.x/templates/) to render the SAM template prior to the build.
 
-**By using the SAM Handler, you are letting SAM build your application, compile a SAM template, and 
-upload artifacts to S3, and then using Sceptre to actually do the deployment of the template to a stack.** 
-In other words, by using this handler with Sceptre, _you skip ever using `sam deploy`; It's not needed_. 
+**By using the SAM Handler, you are letting SAM build your application, compile a SAM template, and
+upload artifacts to S3, and then using Sceptre to actually do the deployment of the template to a stack.**
+In other words, by using this handler with Sceptre, _you skip ever using `sam deploy`; It's not needed_.
 You also shouldn't need a sam config file with deployment defaults, since you'll be using Sceptre to
 deploy rather than SAM.
 
@@ -29,11 +29,11 @@ https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/s
 on how to install SAM for your operating system. (Note: at least on Linux, this requires the ability
 to use `sudo`; If you need to install SAM where permissions escalation is not possible, this won't
 work.)
-* You can use [pipx](https://github.com/pypa/pipx) to install `aws-sam-cli` into an isolated virtual 
-environment where it can have exclusive claim to its dependency versions. This can be done without 
+* You can use [pipx](https://github.com/pypa/pipx) to install `aws-sam-cli` into an isolated virtual
+environment where it can have exclusive claim to its dependency versions. This can be done without
 privilege escalations.
 * If you want to install `aws-sam-cli` along with this handler using `pip`, you can use the "extra"
-like `pip install sceptre-sam-handler[sam]`. However, **using pip to install SAM is generally not 
+like `pip install sceptre-sam-handler[sam]`. However, **using pip to install SAM is generally not
 recommended, according to SAM's own documentation.** This can lead to dependency conflicts, since
 SAM CLI is particular about dependency versions.
 
@@ -133,7 +133,7 @@ https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/s
 The SAM Handler supports using SAM templates that have Jinja logic in them. These Jinja templates
 will have access to the `sceptre_user_data` just like Jinja templates via the normal file handler
 do. This can be useful for implementing additional template logic (such as loops and other actions)
-in the template. 
+in the template.
 
 If you need to pass variables into the Jinja template for reference via Jinja syntax,
 you should pass those variables via `sceptre_user_data`. Remember, resolvers can be used with
@@ -142,10 +142,10 @@ in areas that a SAM Template cannot use parameters (such as in Transforms).
 
 ### Resolvers in the SAM Handler parameters
 It's likely that you'll want to use your template_bucket_name as your artifact_bucket_name, so you
-don't need to have a separate bucket for your sam artifacts. However, since template_bucket_name is 
+don't need to have a separate bucket for your sam artifacts. However, since template_bucket_name is
 technically a resolvable property that could be set via `!stack_output` on your StackGroup config,
 you cannot directly reference it in your Stack Config with `{{ template_bucket_name }}` if you defined
-it on the StackGroup Config using a resolver. For more information on _why_ you can't do this, you 
+it on the StackGroup Config using a resolver. For more information on _why_ you can't do this, you
 should read about the [Resolution order of values](
 https://docs.sceptre-project.org/3.1.0/docs/stack_config.html#resolution-order-of-values) for Sceptre
 Stack Configs on Sceptre's documentation.
@@ -164,7 +164,7 @@ template:
     path: path/from/my/cwd/template.yaml
     # If your template_bucket_name is inherited from your StackGroup as a resolver, you cannot use
     # {{ template_bucket_name }} to reference it, so you need to use the !stack_attr resolver. But
-    # using !stack_attr will always work for you anyway, so you might as well configure the SAM 
+    # using !stack_attr will always work for you anyway, so you might as well configure the SAM
     # handler that way.
     artifact_bucket_name: !stack_attr template_bucket_name
     # It makes the most sense to use the same prefix as your template_key_prefix so that your SAM
@@ -200,7 +200,7 @@ template:
 parameters:
     my_template_parameter: !stack_output some/other/stack.yaml::SomeOutput
 
-# sceptre_user_data is resolved PRIOR TO building and deploying the template and it is passed to 
+# sceptre_user_data is resolved PRIOR TO building and deploying the template and it is passed to
 # Jinja. So you can use sceptre_user_data to control Jinja logic or render values into the template.
 # And because sceptre_user_data is resolvable, you can use resolvers to pass values and even whole
 # template segments to render into the final SAM template before SAM build is ever invoked.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This handler takes several arguments, two of which are required.
 
 ### Arguments:
 * `path` (string, required): The path **from the current working directory** (NOT the
-* project path) to the SAM Template. Paths to Jinja (.j2) files _are_ supported.
+project path) to the SAM Template. The path _must_ end in either ".yaml" or ".j2".
 * `artifact_bucket_name` (string, required): The bucket name where artifacts should be uploaded to
 on S3 during the packaging process. If your project has a `template_bucket_name`, you can set this
 to `{{ template_bucket_name }}`.

--- a/sam_handler/handler.py
+++ b/sam_handler/handler.py
@@ -140,9 +140,8 @@ class SAM(TemplateHandler):
 
     SAM_ARTIFACT_DIRECTORY = 'sam_artifacts'
     standard_template_extensions = ['.yaml']
-    supported_template_extensions = (
-        standard_template_extensions + TemplateHandler.jinja_template_extensions
-    )
+    jinja_template_extensions = ['.j2']
+    supported_template_extensions = standard_template_extensions + jinja_template_extensions
 
     def __init__(
         self,

--- a/sam_handler/handler.py
+++ b/sam_handler/handler.py
@@ -153,11 +153,13 @@ class SAM(TemplateHandler):
         stack_group_config=None,
         *,
         invoker_class=SamInvoker,
-        get_temp_dir=tempfile.gettempdir
+        get_temp_dir=tempfile.gettempdir,
+        render_jinja_template=helper.render_jinja_template
     ):
         super().__init__(name, arguments, sceptre_user_data, connection_manager, stack_group_config)
         self.invoker_class = invoker_class
         self.get_temp_dir = get_temp_dir
+        self.render_jinja_template = render_jinja_template
 
     def schema(self) -> dict:
         """This is the json schema of the template handler. It is required by Sceptre to define
@@ -251,11 +253,11 @@ class SAM(TemplateHandler):
         if self.sam_template_path.suffix in self.standard_template_extensions:
             return self.sam_template_path
         elif self.sam_template_path.suffix in self.jinja_template_extensions:
-            return self.compile_jinja_template()
+            return self._compile_jinja_template()
 
-    def compile_jinja_template(self) -> Path:
+    def _compile_jinja_template(self) -> Path:
         self.logger.info("Compiling Jinja template...")
-        template_body = helper.render_jinja_template(
+        template_body = self.render_jinja_template(
             str(self.sam_template_path),
             {'sceptre_user_data': self.sceptre_user_data},
             self.stack_group_config.get('j2_environment', {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 TEMPLATE_HANDLER_NAME = 'sceptre-sam-handler'
 TEMPLATE_HANDLER_TYPE = 'sam'


### PR DESCRIPTION
There's a valid use case for wanting to use Jinja logic (loops, variable references, etc...) in SAM templates, just like in normal Sceptre CloudFormation templates. This pull requests adds that capability. 