### PR TITLE
Migrating to Sceptre v4 requirement and ConnectionManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # CHANGELOG
-
 Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 ## Unreleased
 
 <!--- All unreleased items go here  -->
+## 1.0.0
+
+### Changed
+- Updated required version of Sceptre to >=4.0
+- Utilizing the new ConnectionManager's mechanism to create environment variables
 
 ## 0.3.0
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0
 readme-renderer>=24.0
 setuptools>=40.6.2
-sceptre>=2.7.0
+sceptre>=4.0
 tox>=2.9.1,<3.0.0
 twine>=1.12.1
 wheel==0.32.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 1.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    'sceptre>=2.7',
+    'sceptre>=4.0',
 ]
 
 test_requirements = [
@@ -54,7 +54,8 @@ setup(
         "Environment :: Console",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9"
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10"
     ],
     test_suite="tests",
     install_requires=install_requirements,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.3.1"
+__version__ = "1.0.0"
 
 TEMPLATE_HANDLER_NAME = 'sceptre-sam-handler'
 TEMPLATE_HANDLER_TYPE = 'sam'


### PR DESCRIPTION
This migrates the SAM handler to Sceptre v4. 

It is currently expected that tests are going to be failing; This cannot be released until Sceptre V4 is released.